### PR TITLE
Refactor again and add javadoc

### DIFF
--- a/checker/src/org/checkerframework/checker/initialization/InitializationStore.java
+++ b/checker/src/org/checkerframework/checker/initialization/InitializationStore.java
@@ -172,7 +172,7 @@ public class InitializationStore<V extends CFAbstractValue<V>,
     @Override
     protected void internalVisualize(CFGVisualizer<V, S, ?> viz) {
         super.internalVisualize(viz);
-        viz.visualizeKeyValue("initialized fields", initializedFields);
+        viz.visualizeStoreKeyVal("initialized fields", initializedFields);
     }
 
     public Map<FieldAccess, V> getFieldValues() {

--- a/checker/src/org/checkerframework/checker/initialization/InitializationStore.java
+++ b/checker/src/org/checkerframework/checker/initialization/InitializationStore.java
@@ -16,13 +16,13 @@ import org.checkerframework.dataflow.analysis.FlowExpressions.ClassName;
 import org.checkerframework.dataflow.analysis.FlowExpressions.FieldAccess;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
 import org.checkerframework.dataflow.analysis.FlowExpressions.ThisReference;
+import org.checkerframework.dataflow.cfg.CFGVisualizer;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.framework.flow.CFAbstractAnalysis;
 import org.checkerframework.framework.flow.CFAbstractStore;
 import org.checkerframework.framework.flow.CFAbstractValue;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.QualifierHierarchy;
-
 import org.checkerframework.javacutil.AnnotationUtils;
 
 /**
@@ -170,9 +170,9 @@ public class InitializationStore<V extends CFAbstractValue<V>,
     }
 
     @Override
-    protected void internalDotOutput(StringBuilder result) {
-        super.internalDotOutput(result);
-        result.append("  initialized fields = " + initializedFields + "\\n");
+    protected void internalVisualize(CFGVisualizer<V, S, ?> viz) {
+        super.internalVisualize(viz);
+        viz.visualizeKeyValue("initialized fields", initializedFields);
     }
 
     public Map<FieldAccess, V> getFieldValues() {

--- a/checker/src/org/checkerframework/checker/lock/LockStore.java
+++ b/checker/src/org/checkerframework/checker/lock/LockStore.java
@@ -133,7 +133,7 @@ public class LockStore extends CFAbstractStore<CFValue, LockStore> {
      */
     @Override
     protected void internalVisualize(CFGVisualizer<CFValue, LockStore, ?> viz) {
-        viz.visualizeKeyValue("inConstructorOrInitializer", inConstructorOrInitializer);
+        viz.visualizeStoreKeyVal("inConstructorOrInitializer", inConstructorOrInitializer);
         super.internalVisualize(viz);
     }
 }

--- a/checker/src/org/checkerframework/checker/lock/LockStore.java
+++ b/checker/src/org/checkerframework/checker/lock/LockStore.java
@@ -9,6 +9,7 @@ import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.checker.lock.qual.LockHeld;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.ArrayAccess;
+import org.checkerframework.dataflow.cfg.CFGVisualizer;
 import org.checkerframework.framework.flow.CFAbstractAnalysis;
 import org.checkerframework.framework.flow.CFAbstractStore;
 import org.checkerframework.framework.flow.CFValue;
@@ -131,9 +132,8 @@ public class LockStore extends CFAbstractStore<CFValue, LockStore> {
      * {@inheritDoc}
      */
     @Override
-    protected void internalDotOutput(StringBuilder result) {
-        result.append("  inConstructorOrInitializer = " + inConstructorOrInitializer
-                + "\\n");
-        super.internalDotOutput(result);
+    protected void internalVisualize(CFGVisualizer<CFValue, LockStore, ?> viz) {
+        viz.visualizeKeyValue("inConstructorOrInitializer", inConstructorOrInitializer);
+        super.internalVisualize(viz);
     }
 }

--- a/checker/src/org/checkerframework/checker/nullness/NullnessStore.java
+++ b/checker/src/org/checkerframework/checker/nullness/NullnessStore.java
@@ -56,7 +56,7 @@ public class NullnessStore extends
     @Override
     protected void internalVisualize(CFGVisualizer<NullnessValue, NullnessStore, ?> viz) {
         super.internalVisualize(viz);
-        viz.visualizeKeyValue("isPolyNonNull", isPolyNullNull);
+        viz.visualizeStoreKeyVal("isPolyNonNull", isPolyNullNull);
     }
 
     public boolean isPolyNullNull() {

--- a/checker/src/org/checkerframework/checker/nullness/NullnessStore.java
+++ b/checker/src/org/checkerframework/checker/nullness/NullnessStore.java
@@ -3,6 +3,7 @@ package org.checkerframework.checker.nullness;
 import org.checkerframework.checker.initialization.InitializationStore;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
+import org.checkerframework.dataflow.cfg.CFGVisualizer;
 import org.checkerframework.framework.flow.CFAbstractAnalysis;
 import org.checkerframework.framework.flow.CFAbstractStore;
 
@@ -53,9 +54,9 @@ public class NullnessStore extends
     }
 
     @Override
-    protected void internalDotOutput(StringBuilder result) {
-        super.internalDotOutput(result);
-        result.append("  isPolyNonNull = " + isPolyNullNull + "\\n");
+    protected void internalVisualize(CFGVisualizer<NullnessValue, NullnessStore, ?> viz) {
+        super.internalVisualize(viz);
+        viz.visualizeKeyValue("isPolyNonNull", isPolyNullNull);
     }
 
     public boolean isPolyNullNull() {

--- a/dataflow/src/org/checkerframework/dataflow/analysis/Store.java
+++ b/dataflow/src/org/checkerframework/dataflow/analysis/Store.java
@@ -64,5 +64,8 @@ public interface Store<S extends Store<S>> {
     boolean canAlias(FlowExpressions.Receiver a,
                      FlowExpressions.Receiver b);
 
+    /** delegate visualize responsibility to a visualizer
+     * @param viz the visualizer that visualize this store
+     */
     void visualize(CFGVisualizer<?, S, ?> viz);
 }

--- a/dataflow/src/org/checkerframework/dataflow/analysis/Store.java
+++ b/dataflow/src/org/checkerframework/dataflow/analysis/Store.java
@@ -1,5 +1,7 @@
 package org.checkerframework.dataflow.analysis;
 
+import org.checkerframework.dataflow.cfg.CFGVisualizer;
+
 /**
  * A store is used to keep track of the information that the org.checkerframework.dataflow analysis
  * has accumulated at any given point in time.
@@ -62,9 +64,5 @@ public interface Store<S extends Store<S>> {
     boolean canAlias(FlowExpressions.Receiver a,
                      FlowExpressions.Receiver b);
 
-    /** @return Whether the Store supports DOT graph output. */
-    boolean hasDOToutput();
-
-    /** @return The store encoded as a DOT graph for visualization. */
-    String toDOToutput();
+    void visualize(CFGVisualizer<?, S, ?> viz);
 }

--- a/dataflow/src/org/checkerframework/dataflow/analysis/TransferInput.java
+++ b/dataflow/src/org/checkerframework/dataflow/analysis/TransferInput.java
@@ -280,22 +280,4 @@ public class TransferInput<A extends AbstractValue<A>, S extends Store<S>> {
         }
     }
 
-    public boolean hasDOToutput() {
-        return true;
-    }
-
-    public String toDOToutput() {
-        if (store == null) {
-            if (thenStore.hasDOToutput()) {
-                return "[then=" + thenStore.toDOToutput() + ", else=" + elseStore.toDOToutput() + "]";
-            }
-            return "[then=" + thenStore + ", else=" + elseStore + "]";
-        } else {
-            if (store.hasDOToutput()) {
-                return "[" + store.toDOToutput() + "]";
-            }
-            return "[" + store + "]";
-        }
-    }
-
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/CFGVisualizer.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/CFGVisualizer.java
@@ -10,6 +10,7 @@ import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.Store;
 import org.checkerframework.dataflow.analysis.TransferFunction;
 import org.checkerframework.dataflow.cfg.block.Block;
+import org.checkerframework.dataflow.cfg.block.SpecialBlock;
 import org.checkerframework.dataflow.cfg.node.Node;
 
 import java.util.Map;
@@ -56,35 +57,98 @@ public interface CFGVisualizer<A extends AbstractValue<A>,
     /*@Nullable*/ Map<String, Object> visualize(ControlFlowGraph cfg, Block entry,
             /*@Nullable*/ Analysis<A, S, T> analysis);
 
-    /**
-     * This is a double-direction delegate pattern interface.
+    /** This is a double-direction delegate pattern interface.
      * this method would delegate the visualize responsibility
-     * to the passed store instance.
+     * to the passed {@link Store} instance.
      * Then the store would do something and delegate the 
      * visualize responsibility back to the CFGVisualizer.
      * @param store
      */
     void visualizeStore(S store);
 
+    /**A delegate method called by a {@link CFAbstractStore} to visualize 
+     * the class CanonicalName before calling the internalVisualize() method of CFAbstractStore.
+     * @param classCanonicalName
+     */
     void visualizeStoreHeader(String classCanonicalName);
 
+    /**This method is called by internalVisualize() of CFAbstractStore to visualize its Local Variable
+     * @param localVar
+     * @param value
+     */
+    void visualizeStoreLocalVar(FlowExpressions.LocalVariable localVar, A value);
+
+    /**This method is called by internalVisualize() of CFAbstractStore to visualize the Info of Current Object in this Store
+     * @param value
+     */
+    void visualizeStoreThisVal(A value);
+
+    /**This method is called by internalVisualize() of CFAbstractStore to visualize the Info of fields collected by this Store
+     * @param fieldAccess
+     * @param value
+     */
+    void visualizeStoreFieldVals(FlowExpressions.FieldAccess fieldAccess, A value);
+
+    /**This method is called by internalVisualize() of CFAbstractStore to visualize the Info of Arrays collected by this Store
+     * @param arrayValue
+     * @param value
+     */
+    void visualizeStoreArrayVal(FlowExpressions.ArrayAccess arrayValue, A value);
+
+    /**This method is called by internalVisualize() of CFAbstractStore to visualize 
+     * the Info of pure method calls collected by this Store
+     * @param methodCall
+     * @param value
+     */
+    void visualizeStoreMethodVals(FlowExpressions.PureMethodCall methodCall, A value);
+
+    /**This method is called by internalVisualize() of CFAbstractStore to visualize the Info of class values collected by this Store
+     * @param className
+     * @param value
+     */
+    void visualizeStoreClassVals(FlowExpressions.ClassName className, A value);
+
+    /**This method is called by internalVisualize() of subclasses of CFAbstractStore to visualize
+     * the specific Info collected according to the specific kind of Store 
+     * current these Stores call this method: {@link LockStore}, {@link NullnessStore}, and {@link InitializationStore}
+     * @param keyName the name of the specific Info to be visualize
+     * @param value the value of the specific Info to be visualize
+     */
+    void visualizeStoreKeyVal(String keyName, Object value);
+
+    /**A delegate method called by a {@link CFAbstractStore} to visualize
+     * any info need to be visualize after the internalVisualize() method of CFAbstractStore.
+     */
     void visualizeStoreFooter();
 
-    void visualizeLocalVariable(FlowExpressions.LocalVariable localVar, A value);
+    /**
+     * Visualize a block based on the analysis
+     * @param bb
+     * @param analysis
+     */
+    void visualizeBlock(Block bb, /*@Nullable*/ Analysis<A, S, T> analysis);
 
-    void visualizeThisValue(A value);
+    /**
+     * Visualize a specialBlock
+     * @param sbb
+     */
+    void visualizeSpecialBlock(SpecialBlock sbb);
 
-    void visualizeFieldValues(FlowExpressions.FieldAccess fieldAccess, A value);
+    /**
+     * Visualize the transferInput of a Block based on analysis
+     * @param bb
+     * @param analysis
+     */
+    void visualizeBlockTransferInput(Block bb, Analysis<A, S, T> analysis);
 
-    void visualizeArrayValue(FlowExpressions.ArrayAccess arrayValue, A value);
-
-    void visualizeMethodValues(FlowExpressions.PureMethodCall methodCall, A value);
-
-    void visualizeClassValues(FlowExpressions.ClassName className, A value);
-
-    void visualizeKeyValue(String keyName, Object value);
-
+    /**
+     * visualized a blockNode based on analysis
+     * @param t
+     * @param analysis
+     */
+    void visualizeBlockNode(Node t, /*@Nullable*/ Analysis<A, S, T> analysis);
     /** Shutdown method called once from the shutdown hook of the BaseTypeChecker.
      */
+
     void shutdown();
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/CFGVisualizer.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/CFGVisualizer.java
@@ -6,18 +6,24 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import org.checkerframework.dataflow.analysis.AbstractValue;
 import org.checkerframework.dataflow.analysis.Analysis;
+import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.Store;
 import org.checkerframework.dataflow.analysis.TransferFunction;
 import org.checkerframework.dataflow.cfg.block.Block;
 import org.checkerframework.dataflow.cfg.node.Node;
 
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import javax.lang.model.element.Element;
 
 /**
  * Perform some visualization on a control flow graph.
  * The particular operations depend on the particular implementation.
  */
-public interface CFGVisualizer {
+public interface CFGVisualizer<A extends AbstractValue<A>,
+        S extends Store<S>, T extends TransferFunction<A, S>> {
     /**
      * Initialization method guaranteed to be called once before the
      * first invocation of {@link visualize}.
@@ -47,9 +53,29 @@ public interface CFGVisualizer {
      *            indicate that this information should not be output.
      * @return Possible analysis results, e.g. generated files.
      */
-    <A extends AbstractValue<A>, S extends Store<S>, T extends TransferFunction<A, S>>
     /*@Nullable*/ Map<String, Object> visualize(ControlFlowGraph cfg, Block entry,
             /*@Nullable*/ Analysis<A, S, T> analysis);
+
+    // TODO: javadoc
+    void visualizeStore(S store);
+
+    void visualizeStoreHeader(String classCanonicalName);
+
+    void visualizeStoreFooter();
+
+    void visualizeLocalVariable(FlowExpressions.LocalVariable localVar, A value);
+
+	void visualizeThisValue(A value);
+
+	void visualizeFieldValues(FlowExpressions.FieldAccess fieldAccess, A value);
+
+	void visualizeArrayAccess(FlowExpressions.ArrayAccess arrayAccess, A value);
+
+	void visualizeMethodValues(FlowExpressions.PureMethodCall methodCall, A value);
+
+	void visualizeClassValues(FlowExpressions.ClassName className, A value);
+
+	void visualizeKeyValue(String keyName, Object value);
 
     /** Shutdown method called once from the shutdown hook of the BaseTypeChecker.
      */

--- a/dataflow/src/org/checkerframework/dataflow/cfg/CFGVisualizer.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/CFGVisualizer.java
@@ -56,7 +56,14 @@ public interface CFGVisualizer<A extends AbstractValue<A>,
     /*@Nullable*/ Map<String, Object> visualize(ControlFlowGraph cfg, Block entry,
             /*@Nullable*/ Analysis<A, S, T> analysis);
 
-    // TODO: javadoc
+    /**
+     * This is a double-direction delegate pattern interface.
+     * this method would delegate the visualize responsibility
+     * to the passed store instance.
+     * Then the store would do something and delegate the 
+     * visualize responsibility back to the CFGVisualizer.
+     * @param store
+     */
     void visualizeStore(S store);
 
     void visualizeStoreHeader(String classCanonicalName);
@@ -65,17 +72,17 @@ public interface CFGVisualizer<A extends AbstractValue<A>,
 
     void visualizeLocalVariable(FlowExpressions.LocalVariable localVar, A value);
 
-	void visualizeThisValue(A value);
+    void visualizeThisValue(A value);
 
-	void visualizeFieldValues(FlowExpressions.FieldAccess fieldAccess, A value);
+    void visualizeFieldValues(FlowExpressions.FieldAccess fieldAccess, A value);
 
-	void visualizeArrayAccess(FlowExpressions.ArrayAccess arrayAccess, A value);
+    void visualizeArrayValue(FlowExpressions.ArrayAccess arrayValue, A value);
 
-	void visualizeMethodValues(FlowExpressions.PureMethodCall methodCall, A value);
+    void visualizeMethodValues(FlowExpressions.PureMethodCall methodCall, A value);
 
-	void visualizeClassValues(FlowExpressions.ClassName className, A value);
+    void visualizeClassValues(FlowExpressions.ClassName className, A value);
 
-	void visualizeKeyValue(String keyName, Object value);
+    void visualizeKeyValue(String keyName, Object value);
 
     /** Shutdown method called once from the shutdown hook of the BaseTypeChecker.
      */

--- a/dataflow/src/org/checkerframework/dataflow/cfg/JavaSource2CFGDOT.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/JavaSource2CFGDOT.java
@@ -162,7 +162,7 @@ public class JavaSource2CFGDOT {
         args.put("outdir", outputDir);
         args.put("checkerName", "");
 
-        CFGVisualizer viz = new DOTCFGVisualizer();
+        CFGVisualizer<A, S, T> viz = new DOTCFGVisualizer<A, S, T>();
         viz.init(args);
         Map<String, Object> res = viz.visualize(cfg, cfg.getEntryBlock(), analysis);
         viz.shutdown();

--- a/dataflow/src/org/checkerframework/dataflow/constantpropagation/ConstantPropagationStore.java
+++ b/dataflow/src/org/checkerframework/dataflow/constantpropagation/ConstantPropagationStore.java
@@ -6,6 +6,7 @@ import java.util.Map.Entry;
 
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.Store;
+import org.checkerframework.dataflow.cfg.CFGVisualizer;
 import org.checkerframework.dataflow.cfg.node.IntegerLiteralNode;
 import org.checkerframework.dataflow.cfg.node.LocalVariableNode;
 import org.checkerframework.dataflow.cfg.node.Node;
@@ -152,14 +153,9 @@ public class ConstantPropagationStore implements
         return true;
     }
 
-    @Override
-    public boolean hasDOToutput() {
-        return false;
-    }
-
-    @Override
-    public String toDOToutput() {
-        return "";
-    }
+	@Override
+	public void visualize(CFGVisualizer<?, ConstantPropagationStore, ?> viz) {
+		// Do nothing since ConstantPropagationStore doesn't support visualize
+	}
 
 }

--- a/dataflow/src/org/checkerframework/dataflow/constantpropagation/ConstantPropagationStore.java
+++ b/dataflow/src/org/checkerframework/dataflow/constantpropagation/ConstantPropagationStore.java
@@ -153,7 +153,7 @@ public class ConstantPropagationStore implements
         return true;
     }
 
-	@Override
+    @Override
 	public void visualize(CFGVisualizer<?, ConstantPropagationStore, ?> viz) {
 		// Do nothing since ConstantPropagationStore doesn't support visualize
 	}

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeChecker.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeChecker.java
@@ -516,7 +516,7 @@ public abstract class BaseTypeChecker extends SourceChecker implements BaseTypeC
     protected void shutdownHook() {
         super.shutdownHook();
 
-        CFGVisualizer viz = getTypeFactory().getCFGVisualizer();
+        CFGVisualizer<?, ?, ?> viz = getTypeFactory().getCFGVisualizer();
         if (viz != null) {
             viz.shutdown();
         }

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractStore.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractStore.java
@@ -983,13 +983,16 @@ public abstract class CFAbstractStore<V extends CFAbstractValue<V>, S extends CF
         return "Use a CFGVisualizer to see the Store: " + this.hashCode();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
 	public void visualize(CFGVisualizer<?, S, ?> viz) {
-        ((CFGVisualizer<V, S, ?> ) viz).visualizeStoreHeader(
+        /*This cast is guaranteed be safe, as long as the CFGVisualizer is created by 
+         * CFGVisualizer<Value, Store, TransferFunction> createCFGVisualizer() of GenericAnnotatedTypeFactory*/
+        @SuppressWarnings("unchecked")
+        CFGVisualizer<V, S, ?> casted_viz = (CFGVisualizer<V, S, ?> ) viz;
+        casted_viz.visualizeStoreHeader(
             this.getClass().getCanonicalName());
-        internalVisualize((CFGVisualizer<V, S, ?>) viz);
-        ((CFGVisualizer<V, S, ?> ) viz).visualizeStoreFooter();
+        internalVisualize(casted_viz);
+        casted_viz.visualizeStoreFooter();
     }
 
     /**
@@ -998,22 +1001,22 @@ public abstract class CFAbstractStore<V extends CFAbstractValue<V>, S extends CF
      */
     protected void internalVisualize(CFGVisualizer<V, S, ?> viz) {
         for (Entry<FlowExpressions.LocalVariable, V> entry : localVariableValues.entrySet()) {
-            viz.visualizeLocalVariable(entry.getKey(), entry.getValue());
+            viz.visualizeStoreLocalVar(entry.getKey(), entry.getValue());
         }
         if (thisValue != null) {
-            viz.visualizeThisValue(thisValue);
+            viz.visualizeStoreThisVal(thisValue);
         }
         for (Entry<FlowExpressions.FieldAccess, V> entry : fieldValues.entrySet()) {
-            viz.visualizeFieldValues(entry.getKey(), entry.getValue());
+            viz.visualizeStoreFieldVals(entry.getKey(), entry.getValue());
         }
         for (Entry<FlowExpressions.ArrayAccess, V> entry : arrayValues.entrySet()) {
-            viz.visualizeArrayValue(entry.getKey(), entry.getValue());
+            viz.visualizeStoreArrayVal(entry.getKey(), entry.getValue());
         }
         for (Entry<PureMethodCall, V> entry : methodValues.entrySet()) {
-            viz.visualizeMethodValues(entry.getKey(), entry.getValue());
+            viz.visualizeStoreMethodVals(entry.getKey(), entry.getValue());
         }
         for (Entry<FlowExpressions.ClassName, V> entry : classValues.entrySet()) {
-            viz.visualizeClassValues(entry.getKey(), entry.getValue());
+            viz.visualizeStoreClassVals(entry.getKey(), entry.getValue());
         }
     }
 }

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractStore.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractStore.java
@@ -1007,7 +1007,7 @@ public abstract class CFAbstractStore<V extends CFAbstractValue<V>, S extends CF
             viz.visualizeFieldValues(entry.getKey(), entry.getValue());
         }
         for (Entry<FlowExpressions.ArrayAccess, V> entry : arrayValues.entrySet()) {
-            viz.visualizeArrayAccess(entry.getKey(), entry.getValue());
+            viz.visualizeArrayValue(entry.getKey(), entry.getValue());
         }
         for (Entry<PureMethodCall, V> entry : methodValues.entrySet()) {
             viz.visualizeMethodValues(entry.getKey(), entry.getValue());

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1057,9 +1057,9 @@ public abstract class GenericAnnotatedTypeFactory<
     /**
      * The CFGVisualizer to be used by all CFAbstractAnalysis instances.
      */
-    protected final CFGVisualizer cfgVisualizer;
+    protected final CFGVisualizer<Value, Store, TransferFunction> cfgVisualizer;
 
-    protected CFGVisualizer createCFGVisualizer() {
+    protected CFGVisualizer<Value, Store, TransferFunction> createCFGVisualizer() {
         if (checker.hasOption("flowdotdir")) {
             String flowdotdir = checker.getOption("flowdotdir");
             boolean verbose = checker.hasOption("verbosecfg");
@@ -1069,7 +1069,8 @@ public abstract class GenericAnnotatedTypeFactory<
             args.put("verbose", verbose);
             args.put("checkerName", getCheckerName());
 
-            CFGVisualizer res = new DOTCFGVisualizer();
+            CFGVisualizer<Value, Store, TransferFunction> res =
+                    new DOTCFGVisualizer<Value, Store, TransferFunction>();
             res.init(args);
             return res;
         } else if (checker.hasOption("cfgviz")) {
@@ -1083,7 +1084,8 @@ public abstract class GenericAnnotatedTypeFactory<
             }
             args.put("checkerName", getCheckerName());
 
-            CFGVisualizer res = BaseTypeChecker.invokeConstructorFor(opts[0], null, null);
+            CFGVisualizer<Value, Store, TransferFunction> res =
+                    BaseTypeChecker.invokeConstructorFor(opts[0], null, null);
             res.init(args);
             return res;
         }
@@ -1125,7 +1127,7 @@ public abstract class GenericAnnotatedTypeFactory<
         return res;
     }
 
-    public CFGVisualizer getCFGVisualizer() {
+    public CFGVisualizer<Value, Store, TransferFunction> getCFGVisualizer() {
         return cfgVisualizer;
     }
 }

--- a/framework/src/org/checkerframework/qualframework/base/dataflow/QualStore.java
+++ b/framework/src/org/checkerframework/qualframework/base/dataflow/QualStore.java
@@ -43,7 +43,7 @@ public class QualStore<Q> implements Store<QualStore<Q>> {
         adapter.insertValue(r, analysis.getConverter().getAnnotation(regexAnnotation));
     }
 
-	public void visualize(CFGVisualizer<?, QualStore<Q>, ?> viz) {
+    public void visualize(CFGVisualizer<?, QualStore<Q>, ?> viz) {
         // TODO: this method currently isn't called. The corresponding
         // method on the adapter is called by the AnnotatedTypeFactory.
         // In the future, the QualifiedTypeFactory should call this method

--- a/framework/src/org/checkerframework/qualframework/base/dataflow/QualStore.java
+++ b/framework/src/org/checkerframework/qualframework/base/dataflow/QualStore.java
@@ -2,6 +2,7 @@ package org.checkerframework.qualframework.base.dataflow;
 
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
 import org.checkerframework.dataflow.analysis.Store;
+import org.checkerframework.dataflow.cfg.CFGVisualizer;
 import org.checkerframework.framework.flow.CFStore;
 
 /**
@@ -34,16 +35,6 @@ public class QualStore<Q> implements Store<QualStore<Q>> {
         return adapter.canAlias(a, b);
     }
 
-    @Override
-    public boolean hasDOToutput() {
-        return adapter.hasDOToutput();
-    }
-
-    @Override
-    public String toDOToutput() {
-        return adapter.toDOToutput();
-    }
-
     public CFStore getUnderlyingStore() {
         return adapter;
     }
@@ -51,4 +42,15 @@ public class QualStore<Q> implements Store<QualStore<Q>> {
     public void insertValue(Receiver r, Q regexAnnotation) {
         adapter.insertValue(r, analysis.getConverter().getAnnotation(regexAnnotation));
     }
+
+	public void visualize(CFGVisualizer<?, QualStore<Q>, ?> viz) {
+        // TODO: this method currently isn't called. The corresponding
+        // method on the adapter is called by the AnnotatedTypeFactory.
+        // In the future, the QualifiedTypeFactory should call this method
+        // and something like the following might work:
+        // CFGVisualizer<?, ?, ?> adaptViz = (CFGVisualizer<?, ?, ?>) viz;
+	    // this.adapter.visualize((CFGVisualizer <?, CFStore, ?>) adaptViz);
+        // however, the mismatch between the QualStore<Q> and the
+        // CFStore might require some further refactorings.
+	}
 }


### PR DESCRIPTION
1. add javadoc to the methods in CFGVisualizer and Store.
2. add javadoc to explain the unchecked cast in visualize() of CFAbstractStore
3. extract visualizeBlock() visualizeSpecialBlock() visualizeBlockTransferInput() and visualizeBlockNode() to CFGVisualizer as part of the interface.
4. Change sbDigraph from local var to a field of DOTCFGVisualizer as a shared StringBuilder among the visualise methods.
5. Add field sbBlock in DOTCFGVisualizer as a shared StringBuilder among the visualize Block methods.
   5.Fix indentation issues.
